### PR TITLE
fixing #130, and some RMD Check warnings

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,12 +18,13 @@ BugReports: https://github.com/soodoku/tuber/issues
 Depends:
     R (>= 3.4.0)
 Imports:
+    askpass,
     dplyr,
-    httpuv,
     httr,
     httr2,
     jsonlite,
     magrittr,
+    mime,
     plyr,
     purrr,
     tibble,
@@ -41,4 +42,4 @@ VignetteBuilder:
     knitr
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1

--- a/R/get_playlist_items.R
+++ b/R/get_playlist_items.R
@@ -39,9 +39,9 @@ get_playlist_items <- function(filter = NULL, part = "contentDetails",
                               max_results = 50, video_id = NULL,
                               page_token = NULL, simplify = TRUE, ...) {
 
-  if (max_results < 0 || max_results > 50) {
-    stop("max_results must be a value between 0 and 50.")
-  }
+  # if (max_results < 0 || max_results > 50) {
+  #   stop("max_results must be a value between 0 and 50.")
+  # }
 
   valid_filters <- c("item_id", "playlist_id")
   if (!(names(filter) %in% valid_filters)) {

--- a/R/yt_search.R
+++ b/R/yt_search.R
@@ -51,6 +51,8 @@
 #' Takes one of three values: \code{'any'} (return all videos; Default),
 #' \code{'creativeCommon'} (return videos with Creative Commons
 #' license), \code{'youtube'} (return videos with standard YouTube license).
+#' @param region_code Character. i18nRegion. Default is NULL.
+#' @param relevance_language Character. Default is "en".
 #' @param simplify Boolean. Return a data.frame if \code{TRUE}.
 #' Default is \code{TRUE}.
 #' If \code{TRUE}, it returns a list that carries additional information.
@@ -136,12 +138,12 @@ yt_search <- function(term = NULL, max_results = 50, channel_id = NULL,
     stop("Location radius must be specified with location")
   }
 
-  querylist <- list(part = "snippet", 
-                    q = term, 
+  querylist <- list(part = "snippet",
+                    q = term,
                     maxResults = max_results,
-                    channelId = channel_id, 
+                    channelId = channel_id,
                     type = type,
-                    channelType = channel_type, 
+                    channelType = channel_type,
                     eventType = event_type,
                     location = location,
                     locationRadius = location_radius,
@@ -149,9 +151,9 @@ yt_search <- function(term = NULL, max_results = 50, channel_id = NULL,
                     publishedBefore = published_before,
                     videoDefinition = video_definition,
                     videoCaption = video_caption,
-                    videoType = video_type, 
+                    videoType = video_type,
                     videoSyndicated = video_syndicated,
-                    videoLicense = video_license, 
+                    videoLicense = video_license,
                     regionCode = region_code,
                     relevanceLanguage	= relevance_language,
                     pageToken = page_token)
@@ -180,9 +182,9 @@ yt_search <- function(term = NULL, max_results = 50, channel_id = NULL,
 
     while (is.character(page_token)) {
 
-      a_res <- yt_search(part = "snippet", 
+      a_res <- yt_search(part = "snippet",
                          term = term,
-                         max_results = max_results, 
+                         max_results = max_results,
                          channel_id = channel_id,
                          type = type,
                          relevance_language = relevance_language,

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,9 @@
+# Eliminating 'no visible binding' note
+utils::globalVariables(c('kind',
+                         'etag',
+                         'items',
+                         'snippet',
+                         'add_headers'
+
+))
+

--- a/man/tuber.Rd
+++ b/man/tuber.Rd
@@ -3,8 +3,27 @@
 \docType{package}
 \name{tuber}
 \alias{tuber}
+\alias{tuber-package}
 \title{\pkg{tuber} provides access to the YouTube API V3.}
 \description{
 \pkg{tuber} provides access to the YouTube API V3 via
 RESTful calls.
+}
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/soodoku/tuber}
+  \item Report bugs at \url{https://github.com/soodoku/tuber/issues}
+}
+
+}
+\author{
+\strong{Maintainer}: Gaurav Sood \email{gsood07@gmail.com}
+
+Other contributors:
+\itemize{
+  \item Kate Lyons \email{k.lyons7@gmail.com} [contributor]
+  \item John Muschelli \email{muschellij2@gmail.com} [contributor]
+}
+
 }

--- a/man/yt_search.Rd
+++ b/man/yt_search.Rd
@@ -19,6 +19,8 @@ yt_search(
   video_caption = "any",
   video_license = "any",
   video_syndicated = "any",
+  region_code = NULL,
+  relevance_language = "en",
   video_type = "any",
   simplify = TRUE,
   get_all = TRUE,
@@ -85,6 +87,10 @@ license), \code{'youtube'} (return videos with standard YouTube license).}
 \item{video_syndicated}{Character. Optional. Takes one of two values:
 \code{'any'} (return all videos; Default), \code{'true'}
 (return only syndicated videos)}
+
+\item{region_code}{Character. i18nRegion. Default is NULL.}
+
+\item{relevance_language}{Character. Default is "en".}
 
 \item{video_type}{Character. Optional. Takes one of three values:
 \code{'any'} (return all videos; Default), \code{'episode'}


### PR DESCRIPTION
- Disabled stop error if `max_results > 50` in `get_playlist_items`, fixes #130
- Added 'zzz.R' to suppress 'no visible binding for global variable [xyz]' warning when R CMD check.
- Removed httpuv from imports, as not imported
- added askpass, mime to imports, as imported
- added basic documentation of params  region_code, relevance_languag in `yt_search`
