### PR TITLE
fix get_playlist_items

### DIFF
--- a/R/get_playlist_items.R
+++ b/R/get_playlist_items.R
@@ -61,17 +61,21 @@ get_playlist_items <- function(filter = NULL, part = "contentDetails",
                     pageToken = page_token, videoId = video_id)
   querylist <- c(querylist, filter)
 
-  res <- tuber_GET("playlistItems", querylist, ...)
+  res <- tuber_GET(path = "playlistItems",
+                   query = querylist,
+                   ...)
 
   if (max_results > 50) {
     page_token <- res$nextPageToken
     while (is.character(page_token)) {
-      a_res <- tuber_GET("playlistItems", list(
-        part = part,
-        playlistId = unname(filter["playlistId"]),
-        maxResults = 50,
-        pageToken = page_token
-      ))
+      a_res <- tuber_GET(path = "playlistItems",
+                         query = list(
+                           part = part,
+                           playlistId = unname(filter[["playlistId"]]), ## <--- double brackets
+                           maxResults = 50,
+                           pageToken = page_token
+                         ),
+                         ...) ## <--- pass arguments to tuber_GET
       res <- c(res, a_res)
       page_token <- a_res$nextPageToken
     }
@@ -82,7 +86,7 @@ get_playlist_items <- function(filter = NULL, part = "contentDetails",
     allResultsList <- lapply(allResultsList, unlist)
     res <-
       do.call(
-        rbind.fill,
+        plyr::rbind.fill,
         lapply(
           allResultsList,
           function(x) as.data.frame(t(x), stringsAsFactors = FALSE)
@@ -90,6 +94,6 @@ get_playlist_items <- function(filter = NULL, part = "contentDetails",
       )
   }
 
-  res
+  return(res)
 }
 


### PR DESCRIPTION
fixes issue #132

Correctly passes on arguments to tuber_GET (e.g., auth = "key") when fetching paginated results with max_results > 50.
