### PR TITLE
Fix tests

### DIFF
--- a/tests/testthat/test-get-details.R
+++ b/tests/testthat/test-get-details.R
@@ -8,7 +8,7 @@ test_that("get_video_details runs successfully", {
   options(google_token = google_token)
 
   get_info <- get_video_details(video_id = "N708P-A45D0")
-  expect_that(get_info, is_a("list"))
+  expect_true(is.list(get_info))
 })
 
 context("Get Details as Data Frame")
@@ -23,5 +23,6 @@ test_that("get_video_details(as.data.frame = TRUE) runs successfully for multipl
   get_info <- get_video_details(
     video_id = c("LDZX4ooRsWs", "yJXTXN4xrI8"),
     as.data.frame = TRUE)
-  expect_that(get_info, is_a("data.frame"))
+  expect_s3_class(get_info, "data.frame")
+  expect_true(all(c("items_kind", "channelTitle") %in% names(get_info)))
 })


### PR DESCRIPTION
## Summary
- modernize expectations in `test-get-details.R`
- check expected columns in data frame result

## Testing
- `Rscript -e 'print(1)'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec5d3e87c832fab0e803ec377b5e8