### PR TITLE
Enhance pagination for high result counts

### DIFF
--- a/R/get_playlist_item_videoids.R
+++ b/R/get_playlist_item_videoids.R
@@ -10,8 +10,8 @@
 #' following: \code{contentDetails, id, snippet, status}. Default:
 #' \code{contentDetails}.
 #' @param max_results Maximum number of items that should be returned.
-#' Integer. Optional. Default is 50.
-#' If over 50, all the results are returned.
+#' Integer. Optional. Default is 50. Values over 50 trigger multiple requests and
+#' may increase API quota usage.
 #' @param simplify returns a data.frame rather than a list.
 #' @param page_token specific page in the result set that should be
 #' returned, optional
@@ -39,8 +39,8 @@ get_playlist_item_videoids <- function(filter = NULL, part = "contentDetails",
                                   max_results = 50, video_id = NULL,
                                   page_token = NULL, simplify = TRUE, ...) {
 
-  if (max_results < 0 || max_results > 50) {
-    stop("max_results must be a value between 0 and 50.")
+  if (max_results <= 0) {
+    stop("max_results must be a positive integer.")
   }
 
   valid_filters <- c("item_id", "playlist_id")
@@ -57,17 +57,23 @@ get_playlist_item_videoids <- function(filter = NULL, part = "contentDetails",
   names(filter) <- filter_name
 
   querylist <- list(part = part,
-                    maxResults = max(min(max_results, 50), 1),
+                    maxResults = min(max_results, 50),
                     pageToken = page_token, videoId = video_id)
   querylist <- c(querylist, filter)
 
   res <- tuber_GET("playlistItems", querylist, ...)
-  res_items <- res$items
+  items <- res$items
+  next_token <- res$nextPageToken
 
-  item_ids <- rep("", length(res_items))
-  for(i in 1:length(res_items)){
-    item_ids[i] <- res_items[[i]]$contentDetails$videoId
+  while (length(items) < max_results && !is.null(next_token)) {
+    querylist$pageToken <- next_token
+    querylist$maxResults <- min(50, max_results - length(items))
+    a_res <- tuber_GET("playlistItems", querylist, ...)
+    items <- c(items, a_res$items)
+    next_token <- a_res$nextPageToken
   }
+
+  item_ids <- sapply(items, function(x) x$contentDetails$videoId)
   return(item_ids)
 }
 

--- a/R/list_channel_resources.R
+++ b/R/list_channel_resources.R
@@ -19,7 +19,8 @@
 #' @param hl  Language used for text values. Optional. The default is \code{en-US}.
 #' For other allowed language codes, see \code{\link{list_langs}}.
 #' @param max_results Maximum number of items that should be returned. Integer.
-#'  Optional. Can be between 0 and 50. The default is 50.
+#'  Optional. Default is 50. Values over 50 will trigger additional requests and
+#'  may increase API quota usage.
 #' @param page_token specific page in the result set that should be returned,
 #' optional
 #' @param \dots Additional arguments passed to \code{\link{tuber_GET}}.
@@ -42,8 +43,8 @@
 
 list_channel_resources <- function(filter = NULL, part = "contentDetails",
                          max_results = 50, page_token = NULL, hl = "en-US", ...) {
-  if (max_results < 0 | max_results > 50) {
-    stop("max_results only takes a value between 0 and 50.")
+  if (max_results <= 0) {
+    stop("max_results must be a positive integer.")
   }
   if (!(names(filter) %in% c("category_id", "username", "channel_id"))) {
     stop("filter can only take one of three values: category_id,
@@ -82,12 +83,23 @@ list_channel_resources <- function(filter = NULL, part = "contentDetails",
                                                       names(translate_filter))])
   names(filter)      <- yt_filter_name
   
-  querylist <- list(part = part, maxResults = max_results,
+  querylist <- list(part = part, maxResults = min(max_results, 50),
                     pageToken = page_token, hl = hl)
   querylist <- c(querylist, filter)
-  
+
   res <- tuber_GET("channels", querylist, ...)
-  
+  items <- res$items
+  next_token <- res$nextPageToken
+
+  while (length(items) < max_results && !is.null(next_token)) {
+    querylist$pageToken <- next_token
+    querylist$maxResults <- min(50, max_results - length(items))
+    a_res <- tuber_GET("channels", querylist, ...)
+    items <- c(items, a_res$items)
+    next_token <- a_res$nextPageToken
+  }
+
+  res$items <- items
   res
 }
 

--- a/R/yt_search.R
+++ b/R/yt_search.R
@@ -18,7 +18,8 @@
 #' @param max_results Maximum number of items that should be returned in total.
 #' Integer. Optional. Can be between 1 and 500. Default is 50. If
 #' \code{get_all = TRUE}, multiple API calls are made until this many
-#' results are collected (subject to YouTube limits). Search results are
+#' results are collected (subject to YouTube limits). Requesting a large number
+#' of results will consume more API quota. Search results are
 #' constrained to a maximum of 500 videos if type is video and we have a
 #' value of \code{channel_id}.
 #' @param channel_id Character. Only return search results from this
@@ -71,7 +72,8 @@
 #' pages. Default is \code{TRUE}.
 #' Result is a \code{data.frame}. Optional.
 #' @param max_pages Maximum number of pages to retrieve when get_all is TRUE.
-#' Default is 10. Set higher for more results, but be aware of API quota limits.
+#' Default is Inf (no page limit). Setting a lower value can reduce API quota
+#' usage.
 #' @param \dots Additional arguments passed to \code{\link{tuber_GET}}.
 #'
 #' @return data.frame with 16 elements: \code{video_id, publishedAt,
@@ -119,7 +121,7 @@ yt_search <- function(term = NULL, max_results = 50, channel_id = NULL,
                       video_license = "any", video_syndicated = "any",
                       region_code = NULL, relevance_language = "en",
                       video_type = "any", simplify = TRUE, get_all = TRUE,
-                      page_token = NULL, max_pages = 10, ...) {
+                      page_token = NULL, max_pages = Inf, ...) {
 
   # Input validation
   if (!is.character(term) || is.null(term)) stop("Must specify a search term.\n")

--- a/tests/testthat/test-get-playlists.R
+++ b/tests/testthat/test-get-playlists.R
@@ -1,0 +1,10 @@
+context("Get Playlists")
+
+test_that("get_playlists returns >50 results when requested", {
+  skip_on_cran()
+  google_token <- readRDS("token_file.rds.enc")$google_token
+  options(google_token = google_token)
+
+  res <- get_playlists(filter = c(channel_id = "UCBR8-60-B28hp2BmDPdntcQ"), max_results = 55)
+  expect_true(length(res$items) >= 55)
+})

--- a/tests/testthat/test-yt-search.R
+++ b/tests/testthat/test-yt-search.R
@@ -9,3 +9,13 @@ test_that("yt_search obeys max_results", {
   expect_s3_class(res, "data.frame")
   expect_equal(nrow(res), 5)
 })
+
+test_that("yt_search returns >50 results when requested", {
+  skip_on_cran()
+  google_token <- readRDS("token_file.rds.enc")$google_token
+  options(google_token = google_token)
+
+  res <- yt_search(term = "cats", type = "video", max_results = 55)
+  expect_s3_class(res, "data.frame")
+  expect_true(nrow(res) >= 55)
+})


### PR DESCRIPTION
## Summary
- support unlimited result pagination across many API wrappers
- document potential quota impact when requesting more than 50 results
- test searching and fetching playlists for >50 items

## Testing
- `Rscript -e "library(testthat); testthat::test_dir('tests/testthat')"` *(fails: there is no package called ‘testthat’)*

------
https://chatgpt.com/codex/tasks/task_e_686eca158e74832f9690d618498b2079