### PR TITLE
Add pkgdown workflow for GitHub Pages deployment

### DIFF
--- a/.github/workflows/pkgdown.yml
+++ b/.github/workflows/pkgdown.yml
@@ -1,0 +1,34 @@
+name: pkgdown
+
+on:
+  push:
+    branches: [ master ]
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+jobs:
+  pkgdown:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
+
+      - uses: r-lib/actions/pkgdown@v2
+        with:
+          pkgdown_branch: gh-pages
+          pkgdown_path: docs

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,5 +1,5 @@
 
-url: https://soodoku.github.io/tuber/
+url: https://gojiplus.github.io/tuber/
 
 template:
   bootstrap: 5


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the pkgdown site and deploys it to the gh-pages branch
- align the pkgdown site URL with the gojiplus GitHub Pages hostname

## Testing
- attempted `Rscript -e 'pkgdown::build_site()'` *(fails: Rscript not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d0df6c4594832f93bdd8e089fe0444